### PR TITLE
Don't output duplicate sockets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/alicebob/procspy"
+	"github.com/weaveworks/procspy"
 )
 
 func main() {

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package procspy_test
 import (
 	"fmt"
 
-	"github.com/alicebob/procspy"
+	"github.com/weaveworks/procspy"
 )
 
 func Example() {

--- a/lsproc/lsproc.go
+++ b/lsproc/lsproc.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/alicebob/procspy"
+	"github.com/weaveworks/procspy"
 )
 
 func main() {

--- a/procnet.go
+++ b/procnet.go
@@ -11,6 +11,7 @@ type ProcNet struct {
 	c                       Connection
 	wantedState             uint
 	bytesLocal, bytesRemote [16]byte
+	seen                    map[uint64]struct{}
 }
 
 // NewProcNet gives a new ProcNet parser.
@@ -19,6 +20,7 @@ func NewProcNet(b []byte, wantedState uint) *ProcNet {
 		b:           b,
 		c:           Connection{},
 		wantedState: wantedState,
+		seen:        map[uint64]struct{}{},
 	}
 }
 
@@ -59,6 +61,10 @@ again:
 	p.c.RemoteAddress, p.c.RemotePort = scanAddressNA(remote, &p.bytesRemote)
 	p.c.inode = parseDec(inode)
 	p.b = nextLine(b)
+	if _, alreadySeen := p.seen[p.c.inode]; alreadySeen {
+		goto again
+	}
+	p.seen[p.c.inode] = struct{}{}
 	return &p.c
 }
 

--- a/procnet_test.go
+++ b/procnet_test.go
@@ -136,3 +136,27 @@ broken line
 	}
 
 }
+
+func TestProcNetFiltersDuplicates(t *testing.T) {
+	testString := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout Inode                                                     
+   0: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0                      
+   1: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0                      
+`
+	p := NewProcNet([]byte(testString), tcpEstablished)
+	expected := Connection{
+		LocalAddress:  net.IP([]byte{0, 0, 0, 0}),
+		LocalPort:     0xa6c0,
+		RemoteAddress: net.IP([]byte{0, 0, 0, 0}),
+		RemotePort:    0x0,
+		inode:         5107,
+	}
+	have := p.Next()
+	want := expected
+	if !reflect.DeepEqual(*have, want) {
+		t.Errorf("transport 4 error. Got\n%+v\nExpected\n%+v\n", *have, want)
+	}
+	if got := p.Next(); got != nil {
+		t.Errorf("p.Next() wasn't empty")
+	}
+
+}


### PR DESCRIPTION
When processes fork, a socket will appear in both ```/proc/<parent>/net/tcp```
and in ```/proc/<child>/net/tcp```. This tracks which inodes we've already seen
and refrains from outputting them.

Fixes https://github.com/weaveworks/scope/issues/300

Also, removes `alicebob` from the imports, so that the tests pass on travis.